### PR TITLE
feat: add pre-push hook to prevent direct pushes to master/main branch

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+
+branch="$(git rev-parse --abbrev-ref HEAD)"
+
+if [ "$branch" = "master" ] || [ "$branch" = "main" ]; then
+  echo "🚫 Direct pushes to master/main branch are not allowed!"
+  echo "Please create a Pull Request instead."
+  echo ""
+  echo "Steps:"
+  echo "  1. Create a feature branch: git checkout -b feature/your-feature"
+  echo "  2. Push your feature branch: git push origin feature/your-feature"
+  echo "  3. Create a PR on GitHub to merge into master"
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Implemented a Git pre-push hook that blocks direct pushes to the main/master branches. When triggered, it displays guidance on how to proceed and aborts the push; other branches continue unaffected. This enforces local branch safety and aligns contributor workflows, reducing accidental pushes and maintaining a cleaner history. No user-facing functionality is affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->